### PR TITLE
Add scheduled cron jobs for testing workflows

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'go/**'
   workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   test:

--- a/.github/workflows/java-test.yml
+++ b/.github/workflows/java-test.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'java/**'
   workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   test:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'nodejs/**'
   workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   test:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'python/**'
   workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   test:

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'crates/**'
   workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   test:


### PR DESCRIPTION
Introduce scheduled cron jobs for various testing workflows, ensuring regular automated testing for Go, Java, Node.js, Python, and Rust projects.